### PR TITLE
write output to location given by env variable

### DIFF
--- a/R/write-docs.R
+++ b/R/write-docs.R
@@ -1,4 +1,4 @@
-write_docs <- function(X) {
-  purrr::walk(dirname(X$new_path), dir.create, recursive = TRUE, showWarnings = FALSE)
-  purrr::walk2(X$new_text, X$new_path, readr::write_file)
+write_docs <- function(X, output_location = ".") {
+  purrr::walk(dirname(file.path(output_location, X$new_path)), dir.create, recursive = TRUE, showWarnings = FALSE)
+  purrr::walk2(X$new_text, file.path(output_location, X$new_path), readr::write_file)
 }

--- a/pages2docs.R
+++ b/pages2docs.R
@@ -2,7 +2,7 @@ source("R/mkdocs-pages-out.R")
 source("R/read-pages.R")
 source("R/write-docs.R")
 
-pages_out <- file.path(Sys.getenv("PAGESPATH")) |>
+file.path(Sys.getenv("PAGESPATH")) |>
   read_pages(years = 2023) |>
   mkdocs_pages_out() |>
-  write_docs()
+  write_docs(output_location = Sys.getenv("OUTPATH"))


### PR DESCRIPTION
Instead of writing to the project folder the output now is written to a folder given by the value of the OUTPATH environment variable.